### PR TITLE
Add cron command customization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ MAINTAINER Siarhei Navatski <navatski@gmail.com>, Andrey Aleksandrov <alex.demio
 ENV VERSION="1.6.7" \
     RELEASE_DATE="11.06.2017" \
     CRON_TIMEOUT="0 * * * *" \
+    CRON_COMMAND="php -q /data/htdocs/engine.php >> /var/log/nginx/torrentmonitor_cron_error.log 2>\&1" \
     PHP_TIMEZONE="UTC" \
     PHP_MEMORY_LIMIT="512M" \
     LD_PRELOAD="/usr/local/lib/preloadable_libiconv.so"

--- a/Dockerfile-armhf
+++ b/Dockerfile-armhf
@@ -10,6 +10,7 @@ MAINTAINER Siarhei Navatski <navatski@gmail.com>, Andrey Aleksandrov <alex.demio
 ENV VERSION="1.6.7" \
     RELEASE_DATE="11.06.2017" \
     CRON_TIMEOUT="0 * * * *" \
+    CRON_COMMAND="php -q /data/htdocs/engine.php >> /var/log/nginx/torrentmonitor_cron_error.log 2>\&1" \
     PHP_TIMEZONE="UTC" \
     PHP_MEMORY_LIMIT="512M" \
     LD_PRELOAD="/usr/local/lib/preloadable_libiconv.so"

--- a/rootfs/init
+++ b/rootfs/init
@@ -14,6 +14,7 @@ sed -i "s#PHP_MEMORY_LIMIT#${PHP_MEMORY_LIMIT}#" /etc/php5/cli/php.ini
 
 # Set cron timeuot for engine.php
 sed -i "s#CRON_TIMEOUT#${CRON_TIMEOUT}#" /var/spool/cron/crontabs/nginx
+sed -i "s#CRON_COMMAND#${CRON_COMMAND}#" /var/spool/cron/crontabs/nginx
 
 # Set owner for app directory
 chown -R nginx:nginx /data/htdocs

--- a/rootfs/var/spool/cron/crontabs/nginx
+++ b/rootfs/var/spool/cron/crontabs/nginx
@@ -1,1 +1,1 @@
-CRON_TIMEOUT php -q /data/htdocs/engine.php >> /var/log/nginx/torrentmonitor_cron_error.log 2>&1
+CRON_TIMEOUT CRON_COMMAND


### PR DESCRIPTION
Add environment variable (option) to customize cron command. It is useful, for example, when we need to use more complicated log/debug mode.
Should be applied after the previous pull request.