### PR TITLE
Compile and install local gnu-libiconv-1.15-r3.apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@
 FROM alpine:3.15.6 AS apk-builder
 
 RUN apk --no-cache add \
-    alpine-sdk \
-    sudo \
-    && \
+        alpine-sdk \
+        sudo \
+        && \
     adduser -D builduser && \
     addgroup builduser abuild && \
     addgroup builduser wheel && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # apk builder
-FROM alpine:3.15.6 as apk-builder
+FROM alpine:3.15.6 AS apk-builder
 
 RUN apk --no-cache add \
     alpine-sdk \
@@ -20,7 +20,7 @@ RUN abuild-keygen -an -i -q && \
     abuild -r
 
 # rootfs builder
-FROM alpine:3.15.6 as rootfs-builder
+FROM alpine:3.15.6 AS rootfs-builder
 
 COPY rootfs/ /rootfs/
 COPY patches/ /tmp/


### PR DESCRIPTION
Fixed https://github.com/azinchen/torrentmonitor-dockerized/issues/97

Build gnu-libiconv-1.15-r3 locally instead of relying on external Alpine repository sources.

Changes:

- Added multi-stage build: Introduced an apk-builder stage to compile gnu-libiconv-1.15-r3.apk locally
- Fixed dependency reliability: Replaced external repository dependency with locally compiled package
- Code cleanup: Fixed formatting and compiler warnings in Dockerfile

Technical Details:

- Creates a separate Alpine build environment with necessary tools (alpine-sdk, abuild)
- Builds gnu-libiconv-1.15-r3 from official Alpine 3.13-stable APKBUILD source
- Installs the locally built package
- Maintains the same libiconv version (1.15-r3) for compatibility

Benefits:

- Reproducibility: Consistent builds across different environments
- Maintenance: Reduces potential build failures due to external dependencies

This change ensures the Docker image builds consistently regardless of external repository availability while maintaining the same functionality and libiconv version compatibility.