### PR TITLE
Harden Dockerfile and init: sign locally-built APK, robust patch, validate NGINX_PORT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,23 @@ RUN apk --no-cache add \
     echo '%wheel ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/wheel && \
     chmod 0400 /etc/sudoers.d/wheel
 
+COPY patches/libiconv-1.15-loop_wchar.patch /tmp/
+
 USER builduser
 WORKDIR /home/builduser
 
 RUN abuild-keygen -an -i -q && \
+    mv /home/builduser/.abuild/*.rsa     /home/builduser/.abuild/builder.rsa && \
+    mv /home/builduser/.abuild/*.rsa.pub /home/builduser/.abuild/builder.rsa.pub && \
+    sudo sh -c 'rm -f /etc/apk/keys/*.rsa.pub; cp /home/builduser/.abuild/builder.rsa.pub /etc/apk/keys/builder.rsa.pub' && \
+    sed -i 's|^PACKAGER_PRIVKEY=.*|PACKAGER_PRIVKEY="/home/builduser/.abuild/builder.rsa"|' /home/builduser/.abuild/abuild.conf && \
+    cp /home/builduser/.abuild/builder.rsa.pub /tmp/builder.rsa.pub && \
     wget -O APKBUILD "https://gitlab.alpinelinux.org/alpine/aports/-/raw/3.13-stable/community/gnu-libiconv/APKBUILD" && \
     abuild checksum && \
     abuild deps && \
     abuild fetch && \
     abuild unpack && \
-    sed -i '39,48d' src/libiconv-1.15/lib/loop_wchar.h && \
+    patch -p1 -d src/libiconv-1.15 < /tmp/libiconv-1.15-loop_wchar.patch && \
     abuild build && \
     abuild rootpkg
 
@@ -71,6 +78,7 @@ LABEL org.opencontainers.image.authors="Alexander Fomichev <fomichev.ru@gmail.co
 
 COPY --from=rootfs-builder /rootfs/ /
 COPY --from=apk-builder /home/builduser/packages /tmp/packages
+COPY --from=apk-builder /tmp/builder.rsa.pub /etc/apk/keys/
 
 RUN apk --no-cache add \
         nginx \
@@ -90,7 +98,7 @@ RUN apk --no-cache add \
         php85-zip \
         php85-dom \
         && \
-    apk --allow-untrusted add /tmp/packages/home/*/gnu-libiconv-1.15-r3.apk && \
+    apk --no-cache add /tmp/packages/home/*/gnu-libiconv-1.15-r*.apk && \
     rm -rf /tmp/* && \
     rm -rf /var/cache/apk/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,11 @@ COPY patches/libiconv-1.15-loop_wchar.patch /tmp/
 USER builduser
 WORKDIR /home/builduser
 
-RUN abuild-keygen -an -i -q && \
+RUN abuild-keygen -an -q && \
     mv /home/builduser/.abuild/*.rsa     /home/builduser/.abuild/builder.rsa && \
     mv /home/builduser/.abuild/*.rsa.pub /home/builduser/.abuild/builder.rsa.pub && \
-    sudo sh -c 'rm -f /etc/apk/keys/*.rsa.pub; cp /home/builduser/.abuild/builder.rsa.pub /etc/apk/keys/builder.rsa.pub' && \
-    sed -i 's|^PACKAGER_PRIVKEY=.*|PACKAGER_PRIVKEY="/home/builduser/.abuild/builder.rsa"|' /home/builduser/.abuild/abuild.conf && \
+    sudo cp /home/builduser/.abuild/builder.rsa.pub /etc/apk/keys/builder.rsa.pub && \
+    echo 'PACKAGER_PRIVKEY="/home/builduser/.abuild/builder.rsa"' > /home/builduser/.abuild/abuild.conf && \
     cp /home/builduser/.abuild/builder.rsa.pub /tmp/builder.rsa.pub && \
     wget -O APKBUILD "https://gitlab.alpinelinux.org/alpine/aports/-/raw/3.13-stable/community/gnu-libiconv/APKBUILD" && \
     abuild checksum && \

--- a/patches/libiconv-1.15-loop_wchar.patch
+++ b/patches/libiconv-1.15-loop_wchar.patch
@@ -1,0 +1,27 @@
+Remove the bogus `extern size_t mbrtowc ();` declaration block that
+conflicts with the prototype provided by modern libcs (musl in Alpine
+3.13+). The block was originally added for systems like BeOS that lack
+`mbstate_t`; it is unnecessary for our build target.
+
+Apply with `patch -p1` from the libiconv-1.15 source root.
+
+--- a/lib/loop_wchar.h
++++ b/lib/loop_wchar.h
+@@ -35,17 +35,7 @@
+ # include <time.h>
+ # include <wchar.h>
+ # define BUF_SIZE 64  /* assume MB_LEN_MAX <= 64 */
+   /* Some systems, like BeOS, have multibyte encodings but lack mbstate_t.  */
+-  extern size_t mbrtowc ();
+-# ifdef mbstate_t
+-#  define mbrtowc(pwc, s, n, ps) (mbrtowc)(pwc, s, n, 0)
+-#  define mbsinit(ps) 1
+-# endif
+-# ifndef mbsinit
+-#  if !HAVE_MBSINIT
+-#   define mbsinit(ps) 1
+-#  endif
+-# endif
+ #endif
+ 
+ /*

--- a/rootfs/init
+++ b/rootfs/init
@@ -47,8 +47,18 @@ echo "php_admin_value[memory_limit] = ${PHP_MEMORY_LIMIT}" >> /etc/php85/php-fpm
 # Set cron timeout for engine.php
 echo "${CRON_TIMEOUT} ${CRON_COMMAND}" > /etc/crontabs/nginx
 
-# Configure nginx port
-sed -i "s/listen[[:space:]]*[0-9]*;/listen ${NGINX_PORT};/" /etc/nginx/conf.d/default.conf
+# Configure nginx port (validate to avoid corrupting nginx config)
+case "$NGINX_PORT" in
+  ''|*[!0-9]*)
+    echo "Invalid NGINX_PORT '${NGINX_PORT}': must be a numeric TCP port between 1 and 65535" >&2
+    exit 1
+    ;;
+esac
+if [ "$NGINX_PORT" -lt 1 ] || [ "$NGINX_PORT" -gt 65535 ]; then
+  echo "Invalid NGINX_PORT '${NGINX_PORT}': must be a numeric TCP port between 1 and 65535" >&2
+  exit 1
+fi
+sed -i "s/listen[[:space:]]*[0-9][0-9]*;/listen ${NGINX_PORT};/" /etc/nginx/conf.d/default.conf
 
 # Force user/group ID
 [ "q${PUID}" == "q" ] || usermod -o -u "$PUID" nginx


### PR DESCRIPTION
Follow-up to #178. Addresses three remaining suggestions from the Copilot review that weren't tackled before merge, plus tightens a related runtime check.

## Changes

### `Dockerfile` — sign the locally-built APK (drop `--allow-untrusted`)
- The `apk-builder` stage now generates a deterministically-named abuild key (`builder.rsa` / `builder.rsa.pub`) and exposes the public key at a fixed path.
- The final stage copies that pubkey into `/etc/apk/keys/` so the locally-built `gnu-libiconv` package installs through the normal trusted path. Removes the `--allow-untrusted` weakening of the supply-chain trust model for the final image.

### `Dockerfile` — wildcard the gnu-libiconv filename
- Replaces hard-coded `gnu-libiconv-1.15-r3.apk` with `gnu-libiconv-1.15-r*.apk` so a `pkgrel` bump in the upstream APKBUILD does not break the build.

### `Dockerfile` + `patches/libiconv-1.15-loop_wchar.patch` — replace brittle `sed` with a real patch
- The previous `sed -i '39,48d' src/libiconv-1.15/lib/loop_wchar.h` was a fixed-line-range edit that would silently mangle the file if upstream ever shifted lines.
- New context-aware patch (`patches/libiconv-1.15-loop_wchar.patch`) is applied with `patch -p1`, which fails loudly on mismatch instead of silently editing the wrong lines.

### `rootfs/init` — validate `NGINX_PORT` before substitution
- `NGINX_PORT` was interpolated directly into a `sed` replacement targeting the nginx config. An empty or non-numeric value would generate an invalid config (or allow injection via crafted values).
- Added validation that the value is numeric and in `[1, 65535]`; tightened the sed regex to require at least one digit (`[0-9][0-9]*`).

## Verification

Built locally with `docker build --no-cache .` and ran smoke tests on the resulting image:

| Check | Result |
| --- | --- |
| Final-stage `apk add` of `gnu-libiconv` without `--allow-untrusted` | OK — `Installing gnu-libiconv (1.15-r3)` |
| `/etc/apk/keys/` contents | 3 stock Alpine keys + `builder.rsa.pub` only (no leftover builder keys leaked) |
| `php85 -r 'iconv("UTF-8","ASCII//TRANSLIT","café")'` | `caf'e` (libiconv preload works) |
| `NGINX_PORT=8080` | `listen 8080;` substituted |
| `NGINX_PORT=abc` | rejected, init exits 1 |
| `NGINX_PORT=99999` | rejected, init exits 1 |
| `NGINX_PORT=0` | rejected, init exits 1 |

No behavioral changes for valid inputs or default settings.