### PR TITLE
Remove QBITTORRENT_CATEGORY support, obsolete since TorrentMonitor 3.0

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -110,7 +110,6 @@
 - `NGINX_PORT="80"` — порт nginx внутри контейнера (по умолчанию: 80)
 - `PUID=<номер>` — UID пользователя для прав на файлы
 - `PGID=<номер>` — GID группы для прав на файлы
-- `QBITTORRENT_CATEGORY="<категория>"` — категория qBittorrent для интеграции с Sonarr
 
 #### Настройка порта
 
@@ -143,29 +142,10 @@ docker container run -d \
   -v /etc/localtime:/etc/localtime:ro \
   -e PHP_TIMEZONE="Europe/Moscow" \
   -e CRON_TIMEOUT="15 8-23 * * *" \
-  -e QBITTORRENT_CATEGORY="tv-sonarr" \
   -e PUID=1001 \
   -e PGID=1000 \
   alfonder/torrentmonitor
 ```
-
-#### Интеграция с Sonarr
-
-TorrentMonitor поддерживает интеграцию с [Sonarr](https://sonarr.tv/) через переменную окружения `QBITTORRENT_CATEGORY`. Эта функция позволяет TorrentMonitor бесшовно работать с существующими настройками Sonarr + qBittorrent.
-
-**Как использовать:**
-1. **Предварительные требования:** Убедитесь, что у вас есть рабочая связка Sonarr + qBittorrent с настроенной категорией (например, "tv-sonarr").
-2. **Настройка:** Настройте Sonarr и qBittorrent так, чтобы они НЕ удаляли автоматически завершённые торренты.
-3. **Настройка TorrentMonitor:** Запустите TorrentMonitor с переменной окружения `QBITTORRENT_CATEGORY`, соответствующей вашей категории Sonarr.
-4. **Порядок действий:**
-   - Добавьте сериал в Sonarr
-   - Sonarr автоматически загрузит торрент в qBittorrent
-   - Удалите торрент из qBittorrent
-   - Добавьте ту же страницу трекера (или лучшую альтернативу) в TorrentMonitor для мониторинга
-   - TorrentMonitor будет отслеживать страницу трекера на предмет обновлений и загружать новые эпизоды в ту же категорию
-   - Sonarr автоматически обнаружит новые эпизоды в категории и обработает их (переименует, переместит в библиотеку и т.д.)
-
-**Важно:** При использовании функции `QBITTORRENT_CATEGORY` вы **должны отключить автообновления** в веб-интерфейсе TorrentMonitor. Самообновления перезаписывают конфигурацию категории и нарушают интеграцию с Sonarr. Чтобы отключить автообновления, перейдите в настройки TorrentMonitor и отключите автоматические обновления.
 
 ---
 
@@ -191,14 +171,12 @@ TorrentMonitor поддерживает интеграцию с [Sonarr](https:/
        environment:
          - PHP_TIMEZONE=Europe/Moscow
          - CRON_TIMEOUT=0 * * * *
-         - QBITTORRENT_CATEGORY=tv-sonarr
    ```
 
 2. **(Опционально) создайте `.env` для переменных:**
    ```env
    PHP_TIMEZONE=Europe/Moscow
    CRON_TIMEOUT=0 * * * *
-   QBITTORRENT_CATEGORY=tv-sonarr
    ```
 
 3. **Запустите сервис:**

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ You can customize TorrentMonitor behavior using these environment variables:
 - `NGINX_PORT="80"` — Nginx listen port inside container (default: 80)
 - `PUID=<number>` — User ID for file ownership
 - `PGID=<number>` — Group ID for file ownership
-- `QBITTORRENT_CATEGORY="<category>"` — qBittorrent category for Sonarr integration
 
 #### Port Configuration
 
@@ -143,29 +142,10 @@ docker container run -d \
   -v /etc/localtime:/etc/localtime:ro \
   -e PHP_TIMEZONE="Europe/Moscow" \
   -e CRON_TIMEOUT="15 8-23 * * *" \
-  -e QBITTORRENT_CATEGORY="tv-sonarr" \
   -e PUID=1001 \
   -e PGID=1000 \
   alfonder/torrentmonitor
 ```
-
-#### Sonarr Integration
-
-TorrentMonitor supports integration with [Sonarr](https://sonarr.tv/) through the `QBITTORRENT_CATEGORY` environment variable. This feature allows TorrentMonitor to work seamlessly with existing Sonarr + qBittorrent setups.
-
-**How to use:**
-1. **Prerequisites:** Ensure you have a working Sonarr + qBittorrent setup with a configured category (e.g., "tv-sonarr").
-2. **Configuration:** Configure both Sonarr and qBittorrent to NOT automatically delete completed torrents.
-3. **Setup TorrentMonitor:** Launch TorrentMonitor with the `QBITTORRENT_CATEGORY` environment variable matching your Sonarr category.
-4. **Workflow:** 
-   - Add a TV series to Sonarr
-   - Sonarr will automatically download a torrent to qBittorrent
-   - Remove the torrent from qBittorrent
-   - Add the same tracker page (or a better alternative) to TorrentMonitor for monitoring
-   - TorrentMonitor will watch the tracker page for updates and download new episodes to the same category
-   - Sonarr will automatically detect new episodes in the category and process them (rename, move to library, etc.)
-
-**Important:** When using the `QBITTORRENT_CATEGORY` feature, you **must disable auto-updating** in TorrentMonitor's web interface. Self-updates will overwrite the category configuration and break the Sonarr integration. To disable auto-updates, go to TorrentMonitor settings and turn off automatic updates.
 
 ---
 
@@ -193,14 +173,12 @@ You can run TorrentMonitor with either classic Docker Compose (`docker-compose`)
        environment:
          - PHP_TIMEZONE=Europe/Moscow
          - CRON_TIMEOUT=0 * * * *
-         - QBITTORRENT_CATEGORY=tv-sonarr
    ```
 
 2. **(Optional) Create a `.env` file** to override variables in your compose file:
    ```env
    PHP_TIMEZONE=Europe/Moscow
    CRON_TIMEOUT=0 * * * *
-   QBITTORRENT_CATEGORY=tv-sonarr
    ```
 
 3. **Start the service:**

--- a/rootfs/init
+++ b/rootfs/init
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-PHP_FILE="/data/htdocs/class/qBittorrent.class.php"
 DATE=$(date +%Y.%m.%d\ %H:%M:%S)
 
 crlog () {
@@ -8,29 +7,6 @@ crlog () {
 }
 
 crlog "[${DATE}] Starting container: TorrentMonitor ${TM_VERSION}"
-
-# Handle 'category' entry in PHP file
-if [ -n "$QBITTORRENT_CATEGORY" ]; then
-  INDENT=$(grep -m1 "'root_folder'" "$PHP_FILE" | sed -n 's/^\([[:space:]]*\).*root_folder.*/\1/p')
-  NEW_LINE="${INDENT}'category' => '${QBITTORRENT_CATEGORY}',"
-  if grep -q "'category'" "$PHP_FILE"; then
-    CURRENT_LINE=$(grep "'category'" "$PHP_FILE" | head -n1 | sed 's/^[[:space:]]*//;s/,$//')
-    EXPECTED_LINE="'category' => '${QBITTORRENT_CATEGORY}'"
-    if [ "$CURRENT_LINE" != "$EXPECTED_LINE" ]; then
-      ESCAPED_LINE=$(printf "%s\n" "$NEW_LINE" | sed 's/[\/&]/\\&/g')
-      sed -i "/'category'/s/^[[:space:]]*.*'category' => .*$/$(echo "$ESCAPED_LINE")/" "$PHP_FILE"
-    fi
-  else
-    sed -i "s/\('root_folder' => true\)[[:space:]]*$/\1,/" "$PHP_FILE"
-    ESCAPED_LINE=$(printf "%s\n" "$NEW_LINE" | sed 's/[\/&]/\\&/g')
-    sed -i "/'root_folder' => true,/a\\$ESCAPED_LINE" "$PHP_FILE"
-  fi
-else
-  if grep -q "'category'" "$PHP_FILE"; then
-    sed -i "/'category' => .*,\{0,1\}[[:space:]]*$/d" "$PHP_FILE"
-    sed -i "s/\('root_folder' => true\),[[:space:]]*$/\1/" "$PHP_FILE"
-  fi
-fi
 
 # Populate database if not exists
 test -f /data/htdocs/db/tm.sqlite || cp /data/htdocs/db_schema/tm.sqlite /data/htdocs/db/tm.sqlite


### PR DESCRIPTION
TorrentMonitor 3.0 supports setting the qBittorrent category natively in its web interface, so the container no longer needs to inject the category into `qBittorrent.class.php` via an environment variable.

Changes:
- Remove the category injection/cleanup logic from `rootfs/init` (and the now-unused `PHP_FILE` variable)
- Drop `QBITTORRENT_CATEGORY` from the environment variable list and all examples in `README.md` and `README-RU.md`
- Remove the Sonarr integration section from both READMEs, since it was built around this variable